### PR TITLE
IN-81 | Savita | Infrascripts for creating batch job to run docker image

### DIFF
--- a/batch-job/README.md
+++ b/batch-job/README.md
@@ -1,0 +1,28 @@
+# Batch Job module
+## Usage Example:
+```
+module "my_job" {
+  source = "./batch-job" # Put ref tag corresponding to the version you need
+
+ schedule_enabled                = 0
+  job_queue_arn                   = "disabled"
+  job_timeout                     = 36000
+  env                             = terraform.workspace
+  docker_image                    = "758800610010.dkr.ecr.us-east-1.amazonaws.com/task"
+
+  repository_name = local.pipeline_name
+  task_name = "compliance"
+  task_file_name = "compliance.py"
+  parameters = {}
+  
+  container_vcpus  = 1
+  container_memory = 1800 # MiB
+  job_timeout      = 7200 # Seconds
+  job_queue_arn    = "${data.terraform_remote_state.network.batch_etl_internal_sequential_job_queue_arn}"
+
+  schedule_name                     = "daily"       # (Optional) Name of schedule. Will be used to generate Cloudwatch rule name and Batch Job name. Good values are \"daily\", \"hourly\", \"periodic\", etc.
+  schedule_cron                     = "0 2 * * ? *" # (Optional) Remove this line if you don't need scheduling
+
+  env                      = "${terraform.workspace}"
+}
+```

--- a/batch-job/main.tf
+++ b/batch-job/main.tf
@@ -1,0 +1,181 @@
+locals {
+
+  repository_name_snake_case = replace(var.repository_name, "-", "_")
+  task_name_snake_case = replace(var.task_name, "-", "_")
+
+  schedule_name_snake_case = replace(var.schedule_name, "-", "_")
+  schedule_name_pascal_case = replace(
+  title(replace(local.schedule_name_snake_case, "_", " ")),
+  " ",
+  "",
+  )
+
+  # https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html
+  job_role_name_full = "${local.repository_name_snake_case}_${local.task_name_snake_case}_job_role"
+  job_role_name_hash = join(
+    "",
+    [
+      substr(local.job_role_name_full, 0, 32),
+      md5(substr(local.job_role_name_full, 32, -1)),
+    ],
+  )
+  job_role_name = length(local.job_role_name_full) <= 64 ? local.job_role_name_full : local.job_role_name_hash
+
+  # https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html
+  schedule_role_name_full = "${local.repository_name_snake_case}_${local.task_name_snake_case}_${local.schedule_name_snake_case}"
+  schedule_role_name_hash = join(
+    "",
+    [
+      substr(local.schedule_role_name_full, 0, 32),
+      md5(substr(local.schedule_role_name_full, 32, -1)),
+    ],
+  )
+  schedule_role_name = length(local.schedule_role_name_full) <= 64 ? local.schedule_role_name_full : local.schedule_role_name_hash
+
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html
+  schedule_rule_name_full = "${local.repository_name_snake_case}_${local.task_name_snake_case}_job_schedule"
+  schedule_rule_name_hash = join(
+    "",
+    [
+      substr(local.schedule_rule_name_full, 0, 32),
+      md5(substr(local.schedule_rule_name_full, 32, -1)),
+    ],
+  )
+  schedule_rule_name = length(local.schedule_rule_name_full) <= 64 ? local.schedule_rule_name_full : local.schedule_rule_name_hash
+
+  deploy_schedule = var.schedule_cron == "" ? 0 : 1
+}
+
+
+### Batch ###
+
+resource "aws_batch_job_definition" "main" {
+  name = "${local.repository_name_snake_case}-${local.task_name_snake_case}"
+  type = "container"
+
+  timeout {
+    attempt_duration_seconds = var.job_timeout
+  }
+
+  retry_strategy {
+    attempts = 1
+  }
+
+  parameters = {
+    "default_parameters"  = jsonencode(var.parameters)
+    "parameters"          = "{}"
+  }
+
+  container_properties = <<CONTAINER_PROPERTIES
+{
+  "image": "${var.docker_image}",
+  "vcpus": ${var.container_vcpus},
+  "memory": ${var.container_memory},
+  "command": [
+  ],
+  "jobRoleArn": "${aws_iam_role.main.arn}",
+  "volumes": ${jsonencode(var.container_volumes)},
+  "mountPoints": ${jsonencode(var.container_mount_points)},
+  "environment": [
+    {
+      "name": "AWS_DEFAULT_REGION",
+      "value": "${var.aws_region}"
+    },
+    {
+      "name": "ENV",
+      "value": "${var.env}"
+    },
+    {
+      "name": "TASK_FILE_NAME",
+      "value": "${var.task_file_name}"
+    }
+  ],
+  "ulimits": [],
+  "resourceRequirements": []
+}
+CONTAINER_PROPERTIES
+
+}
+
+resource "aws_iam_role" "main" {
+  name = local.job_role_name
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+#### CloudWatch ####
+
+resource "aws_cloudwatch_event_target" "job_schedule" {
+  count    = local.deploy_schedule
+  rule     = aws_cloudwatch_event_rule.job_schedule[0].name
+  arn      = var.job_queue_arn
+  role_arn = aws_iam_role.job_schedule_event_target[0].arn
+
+  batch_target {
+    job_definition = aws_batch_job_definition.main.arn
+    job_name       = "${aws_batch_job_definition.main.name}-${local.schedule_name_pascal_case}"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "job_schedule" {
+  count               = local.deploy_schedule
+  is_enabled          = var.schedule_enabled
+  name                = local.schedule_rule_name
+  description         = "Schedule for ${aws_batch_job_definition.main.name} job"
+  schedule_expression = "cron(${var.schedule_cron})"
+}
+
+resource "aws_iam_role" "job_schedule_event_target" {
+  count = local.deploy_schedule
+  name  = local.schedule_role_name
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "job_schedule_event_target_role_aws_batch_submit_job_access" {
+  count = local.deploy_schedule
+  name  = "aws_batch_submit_job_access"
+  role  = aws_iam_role.job_schedule_event_target[0].id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "batch:SubmitJob",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+}

--- a/batch-job/outputs.tf
+++ b/batch-job/outputs.tf
@@ -1,0 +1,11 @@
+output "job_definition_name" {
+  value = aws_batch_job_definition.main.name
+}
+
+output "job_role_name" {
+  value = aws_iam_role.main.name
+}
+
+output "job_role_arn" {
+  value = aws_iam_role.main.arn
+}

--- a/batch-job/variables.tf
+++ b/batch-job/variables.tf
@@ -1,0 +1,82 @@
+variable "parameters" {
+  description = "Parameters passed to the task. Must be entered as terraform \"map\" type."
+  type        = map(string)
+  default     = {}
+}
+
+variable "container_volumes" {
+  description = "List of volumes you need to mount." # TODO: Fix type as soon as this issue will be resolved https://github.com/hashicorp/terraform/issues/19898
+  type = any
+  default = []
+}
+
+variable "container_mount_points" {
+  description = "List of mount points for provided volumes." # TODO: Fix type as soon as this issue will be resolved https://github.com/hashicorp/terraform/issues/19898
+  type        = any
+  default     = []
+}
+
+variable "repository_name" {
+  description = "Name of git repository. Is used as a part of path to notebook location on S3."
+}
+
+variable "task_name" {
+  description = "Name of the task"
+}
+
+variable "task_file_name" {
+  description = "File name containing task implementation "
+}
+
+variable "job_retry_attempts" {
+  description = "Number of retries per job attempt."
+  default     = 1
+}
+
+variable "job_timeout" {
+  description = "Job timeout in seconds. This timeout is per attempt."
+  default     = 3600
+}
+
+variable "container_vcpus" {
+  description = "Number of VCPU allocated to container."
+  default     = 1
+}
+
+variable "container_memory" {
+  description = "Memory size in Megabytes allocated to container."
+  default     = 1800
+}
+
+variable "env" {
+  description = "Environment code, like \"qa\", \"staging\", \"production\""
+}
+
+variable "schedule_enabled" {
+  description = "(Optional) To temporarily disable schedule, set this to \"false\"."
+  default     = true
+}
+
+variable "schedule_cron" {
+  description = "(Optional) Cron expression, e.g. \"0 2 * * ? *\". If blank the schedule is not created."
+  default     = ""
+}
+
+variable "schedule_name" {
+  description = "(Optional) Name of schedule. Will be used to generate Cloudwatch rule name and Batch Job name. Good values are \"daily\", \"hourly\", \"periodic\", etc."
+  default     = "schedule"
+}
+
+variable "job_queue_arn" {
+  description = "AWS Batch Job Queue ARN."
+}
+
+variable "aws_region" {
+  description = "AWS Region"
+  default     = "us-east-1"
+}
+
+variable "docker_image" {
+  description = "Docker image used for job. Image must contain installed papercraft."
+  default     = ""
+}


### PR DESCRIPTION
This PR contains terraform scripts to create batch job to run passed docker image. The main idea behind the change was to creating a batch job that can run python scripts, and this one can run any docker image, additionally it can be used to run an image containing python code and its dependencies. Some of the imp input arguments the config expects are mentioned below :

Docker image : which image to run
task file : which python file to run
